### PR TITLE
Convert date/time to epoch timestamp::Search records with date/time in CapMe 

### DIFF
--- a/capme/.js/capme.js
+++ b/capme/.js/capme.js
@@ -18,7 +18,7 @@ $(document).ready(function(){
     numArgs = parseInt($("#formargs").val());
     gotUsr  = $("#username").val().length;
     gotPwd  = $("#password").val().length;
-    
+
     if (numArgs == 8) {
         reqCap("posted");
     }
@@ -31,10 +31,39 @@ $(document).ready(function(){
             $("#password").focus();
         } else {
             $("#password").focus();
-        }    
+        }
     }
- 
+
     $(".capme_submit").click(function() {
+
+        //Get start time value
+        var stimeConvert = document.getElementById("stime").value;
+        var stimeSyntax = ":";
+
+        //If start time value contains stimeSyntax, then convert date to epoch timestamp.
+        if (stimeConvert.indexOf(stimeSyntax) >=0) {
+
+            var d = new Date(stimeConvert);
+            var tz = (d.getTimezoneOffset());
+            var stimeConverted = d.setTime( d.getTime()/1000-(tz*60) );
+
+            document.getElementById("stime").value = stimeConverted;
+        }
+
+        //Get end time value
+        var etimeConvert = document.getElementById("etime").value;
+        var etimeSyntax = ":";
+
+        //If end time value contains etimeSyntax, then convert date to epoch timestamp.
+        if (etimeConvert.indexOf(etimeSyntax) >=0) {
+
+            var d2 = new Date(etimeConvert);
+            var tz2 = (d2.getTimezoneOffset());
+            var etimeConverted = d2.setTime( d2.getTime()/1000-(tz2*60) );
+
+            document.getElementById("etime").value = etimeConverted;
+        }
+
        frmArgs = $('input[value!=""]').length;
        if (frmArgs == 15) {
             reqCap("usefrm");

--- a/capme/.js/capme.js
+++ b/capme/.js/capme.js
@@ -34,53 +34,60 @@ $(document).ready(function(){
         }
     }
 
-    //Toggle start time between epoch and date/time
-    $("#start_toggle").toggle(
+    //Set tooltip for checkboxes
+    $("#stime_checkbox").attr("title", "Convert to date/time format");
+    $("#etime_checkbox").attr("title", "Convert to date/time format");
 
-        function() {
 
-		//Get value of start time from input and convert it to human-readable date/time
-                var stimeVal = document.getElementById("stime").value;
-                var stime_to_ISO = new Date(stimeVal*1000).toISOString().slice(0,-5).replace('T',' ');
+    //Create toggle for start time checkbox
+    $("#stime_checkbox").click(function() {
 
-                document.getElementById("stime").value = stime_to_ISO;
-        },
+	if ($("#stime_checkbox").prop("checked")){
 
-        function() {
+            //Get value of start time from input and convert it to human-readable date/time
+            var stimeVal = document.getElementById("stime").value;
+            var stime_to_ISO = new Date(stimeVal*1000).toISOString().slice(0,-5).replace('T',' ');
 
-                //Get start time and convert it to epoch timestamp
-                var stimeVal = document.getElementById("stime").value;
-                var startDate = new Date(stimeVal);
-                var start_tz_offset = (startDate.getTimezoneOffset());
-                var stimeConverted = startDate.setTime( startDate.getTime()/1000-(start_tz_offset*60) );
+            document.getElementById("stime").value = stime_to_ISO;
+	    $("#stime_checkbox").attr("title", "Convert to epoch format");
+	}
+	else{
 
-                document.getElementById("stime").value = stimeConverted;
+            //Get start time and convert it to epoch timestamp
+            var stimeVal = document.getElementById("stime").value;
+            var startDate = new Date(stimeVal);
+            var start_tz_offset = (startDate.getTimezoneOffset());
+            var stimeConverted = startDate.setTime( startDate.getTime()/1000-(start_tz_offset*60) );
+
+            document.getElementById("stime").value = stimeConverted;
+            $("#stime_checkbox").attr("title", "Convert to date/time format");
         }
-    );
+    });
 
-    //Toggle end time between epoch and date/time
-    $("#end_toggle").toggle(
+    //Create toggle for end time checkbox
+    $("#etime_checkbox").click(function() {
 
-        function() {
+	if ($("#etime_checkbox").prop("checked")){
 
-                //Get value of end time from input  and convert it to human-readable date/time
-                var etimeVal = document.getElementById("etime").value;
-                var etime_to_ISO = new Date(etimeVal*1000).toISOString().slice(0,-5).replace('T',' ');
+	    //Get value of start time from input and convert it to human-readable date/time
+            var stimeVal = document.getElementById("etime").value;
+            var stime_to_ISO = new Date(stimeVal*1000).toISOString().slice(0,-5).replace('T',' ');
 
-                document.getElementById("etime").value = etime_to_ISO;
-        },
+            document.getElementById("etime").value = stime_to_ISO;
+            $("#etime_checkbox").attr("title", "Convert to epoch format");
+        }
+	else{
 
-        function() {
+	    //Get start time and convert it to epoch timestamp
+            var stimeVal = document.getElementById("etime").value;
+            var startDate = new Date(stimeVal);
+            var start_tz_offset = (startDate.getTimezoneOffset());
+            var stimeConverted = startDate.setTime( startDate.getTime()/1000-(start_tz_offset*60) );
 
-                //Get end time value and convert it to epoch timestamp
-                var etimeVal = document.getElementById("etime").value;
-                var endDate = new Date(etimeVal);
-                var end_tz_offset = (endDate.getTimezoneOffset());
-                var etimeConverted = endDate.setTime( endDate.getTime()/1000-(end_tz_offset*60) );
-
-                document.getElementById("etime").value = etimeConverted;
-       }
-    );
+	    document.getElementById("etime").value = stimeConverted;
+                $("#etime_checkbox").attr("title", "Convert to epoch format");
+        }
+    });
 
     $(".capme_submit").click(function() {
 
@@ -113,7 +120,7 @@ $(document).ready(function(){
         }
 
        frmArgs = $('input[value!=""]').length;
-       if (frmArgs == 15) {
+       if (frmArgs == 17) {
             reqCap("usefrm");
         } else {
             theMsg("Please complete all form fields");

--- a/capme/.js/capme.js
+++ b/capme/.js/capme.js
@@ -34,32 +34,80 @@ $(document).ready(function(){
         }
     }
 
+    //Toggle start time between epoch and date/time
+    $("#start_toggle").toggle(
+
+        function() {
+
+		//Get value of start time from input and convert it to human-readable date/time
+                var stimeVal = document.getElementById("stime").value;
+                var stime_to_ISO = new Date(stimeVal*1000).toISOString().slice(0,-5).replace('T',' ');
+
+                document.getElementById("stime").value = stime_to_ISO;
+        },
+
+        function() {
+
+                //Get start time and convert it to epoch timestamp
+                var stimeVal = document.getElementById("stime").value;
+                var startDate = new Date(stimeVal);
+                var start_tz_offset = (startDate.getTimezoneOffset());
+                var stimeConverted = startDate.setTime( startDate.getTime()/1000-(start_tz_offset*60) );
+
+                document.getElementById("stime").value = stimeConverted;
+        }
+    );
+
+    //Toggle end time between epoch and date/time
+    $("#end_toggle").toggle(
+
+        function() {
+
+                //Get value of end time from input  and convert it to human-readable date/time
+                var etimeVal = document.getElementById("etime").value;
+                var etime_to_ISO = new Date(etimeVal*1000).toISOString().slice(0,-5).replace('T',' ');
+
+                document.getElementById("etime").value = etime_to_ISO;
+        },
+
+        function() {
+
+                //Get end time value and convert it to epoch timestamp
+                var etimeVal = document.getElementById("etime").value;
+                var endDate = new Date(etimeVal);
+                var end_tz_offset = (endDate.getTimezoneOffset());
+                var etimeConverted = endDate.setTime( endDate.getTime()/1000-(end_tz_offset*60) );
+
+                document.getElementById("etime").value = etimeConverted;
+       }
+    );
+
     $(".capme_submit").click(function() {
 
         //Get start time value
-        var stimeConvert = document.getElementById("stime").value;
+        var stimeVal = document.getElementById("stime").value;
         var stimeSyntax = ":";
 
         //If start time value contains stimeSyntax, then convert date to epoch timestamp.
-        if (stimeConvert.indexOf(stimeSyntax) >=0) {
+        if (stimeVal.indexOf(stimeSyntax) >=0) {
 
-            var d = new Date(stimeConvert);
-            var tz = (d.getTimezoneOffset());
-            var stimeConverted = d.setTime( d.getTime()/1000-(tz*60) );
+            var startDate = new Date(stimeVal);
+            var start_tz_offset = (startDate.getTimezoneOffset());
+            var stimeConverted = startDate.setTime( startDate.getTime()/1000-(start_tz_offset*60) );
 
             document.getElementById("stime").value = stimeConverted;
         }
 
         //Get end time value
-        var etimeConvert = document.getElementById("etime").value;
+        var etimeVal = document.getElementById("etime").value;
         var etimeSyntax = ":";
 
         //If end time value contains etimeSyntax, then convert date to epoch timestamp.
-        if (etimeConvert.indexOf(etimeSyntax) >=0) {
+        if (etimeVal.indexOf(etimeSyntax) >=0) {
 
-            var d2 = new Date(etimeConvert);
-            var tz2 = (d2.getTimezoneOffset());
-            var etimeConverted = d2.setTime( d2.getTime()/1000-(tz2*60) );
+            var endDate = new Date(etimeVal);
+            var end_tz_offset = (endDate.getTimezoneOffset());
+            var etimeConverted = endDate.setTime( endDate.getTime()/1000-(end_tz_offset*60) );
 
             document.getElementById("etime").value = etimeConverted;
         }

--- a/capme/.js/capme.js
+++ b/capme/.js/capme.js
@@ -85,7 +85,7 @@ $(document).ready(function(){
             var stimeConverted = startDate.setTime( startDate.getTime()/1000-(start_tz_offset*60) );
 
 	    document.getElementById("etime").value = stimeConverted;
-                $("#etime_checkbox").attr("title", "Convert to epoch format");
+                $("#etime_checkbox").attr("title", "Convert to date/time format");
         }
     });
 

--- a/capme/index.php
+++ b/capme/index.php
@@ -167,15 +167,15 @@ capME!
 </tr>
 
 <tr>
-<td class=capme_left id=start_toggle>Start Time:</td>
+<td class=capme_left>Start Time:</td>
 <td class=capme_right><input type=text maxlength=19 id=stime class=capme_selb value="<?php echo $stime;?>" />
-</td>
+<input type=checkbox id=stime_checkbox /></td>
 </tr>
 
 <tr>
-<td class=capme_left id=end_toggle>End Time:</td>
+<td class=capme_left>End Time:</td>
 <td class=capme_right><input type=text maxlength=19 id=etime class=capme_selb value="<?php echo $etime;?>" />
-</td>
+<input type=checkbox id=etime_checkbox /></td>
 </tr>
 
 <tr>

--- a/capme/index.php
+++ b/capme/index.php
@@ -167,13 +167,13 @@ capME!
 </tr>
 
 <tr>
-<td class=capme_left>Start Time:</td>
+<td class=capme_left id=start_toggle>Start Time:</td>
 <td class=capme_right><input type=text maxlength=19 id=stime class=capme_selb value="<?php echo $stime;?>" />
 </td>
 </tr>
 
 <tr>
-<td class=capme_left>End Time:</td>
+<td class=capme_left id=end_toggle>End Time:</td>
 <td class=capme_right><input type=text maxlength=19 id=etime class=capme_selb value="<?php echo $etime;?>" />
 </td>
 </tr>


### PR DESCRIPTION
Reference: https://groups.google.com/forum/#!topic/security-onion/7kB8tA0andU

I was researching the ability to allow manual search for transcripts via a more traditional date/time format.

I took a look at /var/www/so/capme/.js/capme.js and added some lines of JavaScript to convert the date/time (Ex. 2016/02/11 10:01:34) to an epoch timestamp to be used for the backend lookup (Ex. 1455184894) .

I have been able to successfully use the date/time (using known timespans) to access transcripts, and it has not yet impacted normal operation.

To clarify, this has been tested through navigating directly to CapMe and entering the date/time value(s), and does not convert the values presented to CapMe by ELSA, which I'm not sure would be necessary right now.  

I would like to possibly include toggle functionality for the start/end time if you think it would be beneficial. 
