### PR TITLE
Add default date/time text for search and fix checkbox state issue.

### DIFF
--- a/capme/.js/capme.js
+++ b/capme/.js/capme.js
@@ -44,9 +44,11 @@ $(document).ready(function(){
     var stimeSyntax = "-";
         if (stimeVal.indexOf(stimeSyntax) >=0){
 	    $("#stime_checkbox").prop('checked', true);
+            $("#stime_checkbox").attr("title", "Convert to epoch format");
         }
 	else{
 	    $("#stime_checkbox").prop('checked', false);
+            $("#stime_checkbox").attr("title", "Convert to date/time format");
 	}
     });
 
@@ -55,9 +57,11 @@ $(document).ready(function(){
     var etimeSyntax = "-";
         if (etimeVal.indexOf(etimeSyntax) >=0){
             $("#etime_checkbox").prop('checked', true);
+            $("#etime_checkbox").attr("title", "Convert to epoch format");
         }
 	else{
 	    $("#etime_checkbox").prop('checked', false);
+            $("#etime_checkbox").attr("title", "Convert to date/time format");
 	}
     });
 

--- a/capme/.js/capme.js
+++ b/capme/.js/capme.js
@@ -38,6 +38,28 @@ $(document).ready(function(){
     $("#stime_checkbox").attr("title", "Convert to date/time format");
     $("#etime_checkbox").attr("title", "Convert to date/time format");
 
+    //Set checkbox value based on user input
+    $("#stime").blur(function() {
+    var stimeVal = document.getElementById("stime").value;
+    var stimeSyntax = "-";
+        if (stimeVal.indexOf(stimeSyntax) >=0){
+	    $("#stime_checkbox").prop('checked', true);
+        }
+	else{
+	    $("#stime_checkbox").prop('checked', false);
+	}
+    });
+
+    $("#etime").blur(function() {
+    var etimeVal = document.getElementById("etime").value;
+    var etimeSyntax = "-";
+        if (etimeVal.indexOf(etimeSyntax) >=0){
+            $("#etime_checkbox").prop('checked', true);
+        }
+	else{
+	    $("#etime_checkbox").prop('checked', false);
+	}
+    });
 
     //Create toggle for start time checkbox
     $("#stime_checkbox").click(function() {

--- a/capme/index.php
+++ b/capme/index.php
@@ -168,13 +168,13 @@ capME!
 
 <tr>
 <td class=capme_left>Start Time:</td>
-<td class=capme_right><input type=text maxlength=19 id=stime class=capme_selb value="<?php echo $stime;?>" />
+<td class=capme_right><input type=text maxlength=19 id=stime class=capme_selb placeholder="YYYY-MM-DD HH:MM:SS" value="<?php echo $stime;?>" />
 <input type=checkbox id=stime_checkbox /></td>
 </tr>
 
 <tr>
 <td class=capme_left>End Time:</td>
-<td class=capme_right><input type=text maxlength=19 id=etime class=capme_selb value="<?php echo $etime;?>" />
+<td class=capme_right><input type=text maxlength=19 id=etime class=capme_selb placeholder="YYYY-MM-DD HH:MM:SS" value="<?php echo $etime;?>" />
 <input type=checkbox id=etime_checkbox /></td>
 </tr>
 


### PR DESCRIPTION
-Noticed an issue in regard to the checkbox state if initiating a manual search with date/time format (should be checked if using date/time format)--I've identified it and corrected it (capme.js).
-Also added default input text (index.php) for manual search.

Thanks,
Wes
