### PR TITLE
CapMe: only close transcript when 'close' button is clicked

### DIFF
--- a/capme/.css/capme.css
+++ b/capme/.css/capme.css
@@ -157,7 +157,26 @@ td.capme_close {
   border-top-right-radius: 5px;
 }
 
-span.capme_close {
+td.capme_close_button {
+  width: 940px;
+  text-align: right;
+  background: #ffffff;
+  color: #ffffff;
+  font-size: 11px;
+  padding-bottom: 5px;
+  padding-left: 10px;
+  padding-right: 15px;
+  padding-top: 15px;
+  border: 1pt solid #c9c9c9;
+  border-bottom: none;
+  word-wrap: break-word;
+  word-break: break-all;
+  display: inline-block;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+}
+
+span.capme_close_button {
   background-color: #e9e9e9;
   color: #000000;
   font-weight: bold;
@@ -167,7 +186,7 @@ span.capme_close {
   border-radius: 2px;
 }
 
-span.capme_close:hover {
+span.capme_close_button:hover {
   background-color: #ffffff;
   color: #000000;
   cursor: pointer

--- a/capme/.js/capme.js
+++ b/capme/.js/capme.js
@@ -223,7 +223,7 @@ $(document).ready(function(){
                         txt += "<table class=capme_result align=center width=940 cellpadding=0 cellspacing=0>";
                         txt += "<tr>";
                         txt += "<td class=capme_close>";
-                        txt += "<span class=capme_close>close</span>";
+                        txt += "<span class=capme_close_button>close</span>";
                         txt += "</td></tr>";
                         txt += "<tr>";
                         txt += "<td class=capme_text>";
@@ -252,7 +252,7 @@ $(document).ready(function(){
         }
     }
 
-    $(document).on("click", ".capme_close", function() {
+    $(document).on("click", ".capme_close_button", function() {
         $(".capme_result").remove();
         $(".capme_div").show();
         bON('.capme_submit');


### PR DESCRIPTION
I recently noticed the whole `td` for the CapMe 'close' button is clickable, which means that if you click anywhere to the left of the button (even on the opposite side of the transcript), it will close the transcript (I've done this by accident a few times--not a big deal, but noticeable).

I've update the CSS and JavaScript to include a class of `capme_close_button` and the onClick event to enact action when a `td` of this particular class is clicked. 

Therefore, now the transcript will only exit when the actual 'close' button is clicked. 

Of course, there may be a much simpler/better way to do this, but this worked for me. 

Thanks,
Wes
