### PR TITLE
Issue 1007: CapMe: transcript data sometimes overruns the transcript window

### DIFF
--- a/capme/.css/capme.css
+++ b/capme/.css/capme.css
@@ -222,10 +222,18 @@ color:#000;
 }
 
 .txtext_src {
+  display: inline-block;
+  width: inherit;
+  overflow: hidden !important;
+  text-overflow: ellipsis;
   color: #0000ff;
 }
 
 .txtext_dst {
+  display: inline-block;
+  width: inherit;
+  overflow: hidden !important;
+  text-overflow: ellipsis;
   color: #ff0000;
 }
 


### PR DESCRIPTION
This fixes (for me, at least) the transcript window overrun issue noted in Issue #1007:

https://github.com/Security-Onion-Solutions/security-onion/issues/1007

Thanks,
Wes
